### PR TITLE
Updated the fpdf service provider for Laravel 5.4

### DIFF
--- a/src/Anouar/Fpdf/FpdfServiceProvider.php
+++ b/src/Anouar/Fpdf/FpdfServiceProvider.php
@@ -18,8 +18,7 @@ class FpdfServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app['fpdf'] = $this->app->share(function($app)
-        {
+		$this->app->singleton('fpdf', function($app) {
             return new Fpdf;
         });
 	}


### PR DESCRIPTION
The 5.4 release of Laravel dropped the `share` container method and they recommend to use the `singleton` method instead.